### PR TITLE
Fix Auspex chat hyperlinks not displaying correctly

### DIFF
--- a/static/css/auspex-chat.css
+++ b/static/css/auspex-chat.css
@@ -676,6 +676,26 @@
     font-style: italic;
 }
 
+.floating-message-content a {
+    color: #0066cc;
+    text-decoration: underline;
+    cursor: pointer;
+    transition: color 0.2s ease;
+}
+
+.floating-message-content a:hover {
+    color: #0052a3;
+    text-decoration: underline;
+}
+
+.floating-message-content a:visited {
+    color: #551a8b;
+}
+
+.floating-message-content a:active {
+    color: #FF69B4;
+}
+
 /* Responsive adjustments */
 @media (max-width: 768px) {
     .chat-modal .modal-dialog {


### PR DESCRIPTION
- Add explicit CSS styling for links in .floating-message-content
- Links now display in blue (#0066cc) with underlines
- Add hover, visited, and active states
- Fixes issue where color: #333 from parent override default link colors
- Links were rendered but invisible due to CSS specificity